### PR TITLE
Update Yarp.ReverseProxy version to 1.1.2

### DIFF
--- a/src/NextjsStaticHosting.AspNetCore/NextjsStaticHosting.AspNetCore.csproj
+++ b/src/NextjsStaticHosting.AspNetCore/NextjsStaticHosting.AspNetCore.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.1.1" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
A denial of service vulnerability exists in YARP 1.1.1.

Source: https://github.com/microsoft/reverse-proxy/security/advisories/GHSA-jrjw-qgr2-wfcg